### PR TITLE
feat: 웹소켓 통신 시 인증 토큰을 쿼리 스트링으로 서버와 통신하도록 변경

### DIFF
--- a/front/src/api/request.js
+++ b/front/src/api/request.js
@@ -16,7 +16,7 @@ const request = axios.create({
  * localStorage에 저장된 토큰 값을 꺼내 셋팅하도록 변경 
  */
 request.interceptors.request.use(config => {
-    const token = window.localStorage.getItem('authToken')
+    const token = window.sessionStorage.getItem('authToken')
     if (token) {
         config.headers.Authorization = `Bearer ${token}`
     }

--- a/front/src/api/sign/signAPI.js
+++ b/front/src/api/sign/signAPI.js
@@ -8,7 +8,7 @@ export default {
             const token = response.data.data.token
             
             if (token) {
-                window.localStorage.setItem('authToken', token)
+                window.sessionStorage.setItem('authToken', token)
             }
         } catch(error) {
             console.log(error)

--- a/front/src/views/chat/chatRoom/ChatRoomHead.vue
+++ b/front/src/views/chat/chatRoom/ChatRoomHead.vue
@@ -1,7 +1,7 @@
 <template>
     <v-toolbar dark color="primary" flat>
         <v-row class="d-flex align-center">
-            <v-btn icon @click="($router.go(-1))">
+            <v-btn icon @click="goToChatList">
                 <v-icon large>mdi-chevron-left</v-icon>
             </v-btn>
             <v-toolbar-title>{{info.title}}</v-toolbar-title>
@@ -23,6 +23,11 @@ export default {
     watch: {
         info(newVal) {
             this.userCount = newVal
+        }
+    },
+    methods: {
+        goToChatList() {
+            this.$router.push({name: "ChatListView"})
         }
     }
 }

--- a/front/src/views/chat/chatRoom/ChatRoomView.vue
+++ b/front/src/views/chat/chatRoom/ChatRoomView.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="chat-room-container">
-        <ChatRoomHead :info="room"/>
+        <ChatRoomHead :info="room" />
         <ChatRoomBody :info="room" v-on:monitoring="updateUserCount"></ChatRoomBody>
     </div>
 </template>
@@ -15,7 +15,7 @@ export default {
     data() {
         return {
             room: {},
-            pollingRoomData: null,
+            pollingRoomData: null
         }
     },
     created() {

--- a/front/src/views/chat/chatRoom/parts/ChatVoiceComponent.vue
+++ b/front/src/views/chat/chatRoom/parts/ChatVoiceComponent.vue
@@ -28,6 +28,7 @@ export default {
         this.bus.$on("join", this.userJoinEvent)
         this.bus.$on("signalling", this.getMessageFromSignallingServer)
         this.bus.$on("leave", this.handleLeavePeer)
+        this.bus.$on("disconnect", () => this.closeMedia())
     },
     methods: {
         async startVoiceChat(setupData) {
@@ -164,6 +165,9 @@ export default {
                 sdp: connection.localDescription
             }
         },
+        closeMedia() {
+            this.myVoiceStream.getTracks().forEach(track => track.stop())
+        }
     }
 }
 </script>

--- a/server/src/main/java/me/hwanse/chatserver/auth/JwtProvider.java
+++ b/server/src/main/java/me/hwanse/chatserver/auth/JwtProvider.java
@@ -58,26 +58,26 @@ public class JwtProvider {
                 .compact();
     }
 
-    public Optional<Claims> verifyToken(String token) {
+    public Claims verifyToken(String token) {
         try {
-            Claims claims = Jwts.parserBuilder()
+            return Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
-
-            return Optional.of(claims);
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.debug("잘못된 JWT 서명입니다.");
+            throw e;
         } catch (ExpiredJwtException e) {
             log.debug("만료된 JWT 토큰입니다.");
+            throw e;
         } catch (UnsupportedJwtException e) {
             log.debug("지원되지 않는 JWT 토큰입니다.");
+            throw e;
         } catch (IllegalArgumentException e) {
-            log.debug("JWT 토큰이 잘못되었습니다.");
+            log.debug("입력된 JWT 토큰이 잘못되었습니다.");
+            throw e;
         }
-
-        return Optional.empty();
     }
 
     public Optional<Authentication> getAuthentication(Claims claims) {

--- a/server/src/main/java/me/hwanse/chatserver/exception/JwtClaimsVerifyError.java
+++ b/server/src/main/java/me/hwanse/chatserver/exception/JwtClaimsVerifyError.java
@@ -3,7 +3,7 @@ package me.hwanse.chatserver.exception;
 public class JwtClaimsVerifyError extends ServiceRuntimeException {
 
     public JwtClaimsVerifyError() {
-        super("JWT claims verify error occurred. {}");
+        super("JWT claims verify error occurred.");
     }
 
 }


### PR DESCRIPTION
- 웹소켓 스펙 제한 및 SockJS API 에서 헤더 조작을 할 수 없어 쿼리 스트링에 token 을 전달하도록 구현
  - 서버의 jwt 필터에서 쿼리 스트링의 Token 을 파싱할 수 있도록 수정
  - 서버에서 jwt verify exception 발생 시 에러 핸들링 로직 수정
- 채팅 방에서 뒤로 가기 버틑 클릭 시 채팅방에서 사용하던 websocket connection, mediaTrack 이 유지되어있는 문제 개선
  - 뒤로 가기 버튼 클릭 시 ChatRoomBody 컴포넌트 beforeDestroy 훅에 websocket connection, mediaTrack 을 정리하도록 처리