### PR TITLE
feat: chatRoom 도메인 채팅방 관리자 관련 필드 추가 및 API,  테스트 코드 수정

### DIFF
--- a/server/src/main/java/me/hwanse/chatserver/chatroom/ChatRoom.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/ChatRoom.java
@@ -1,12 +1,10 @@
 package me.hwanse.chatserver.chatroom;
 
 import lombok.*;
+import me.hwanse.chatserver.user.User;
 import org.springframework.web.socket.WebSocketSession;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,19 +27,20 @@ public class ChatRoom {
 
     private int userCount;
 
+    private String managerId;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime deletedAt;
 
     private boolean use;
 
-
-    public ChatRoom(String title) {
-        this(title, 5);
+    public ChatRoom(String title, String managerId) {
+        this(title, 5, managerId);
     }
 
-    public ChatRoom(String title, int limitUserCount) {
-        this(null, title, limitUserCount, 0, LocalDateTime.now(), null, true);
+    public ChatRoom(String title, int limitUserCount, String managerId) {
+        this(null, title, limitUserCount, 0, managerId, LocalDateTime.now(), null, true);
     }
 
     public void increaseUserCount() {

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/controller/ChatRoomController.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/controller/ChatRoomController.java
@@ -1,11 +1,13 @@
 package me.hwanse.chatserver.chatroom.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.hwanse.chatserver.api.ApiResult;
 import me.hwanse.chatserver.chatroom.ChatRoom;
 import me.hwanse.chatserver.chatroom.dto.ChatRoomDto;
 import me.hwanse.chatserver.chatroom.dto.CreateChatRoomRequest;
 import me.hwanse.chatserver.chatroom.service.ChatRoomService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -15,6 +17,7 @@ import java.util.stream.Collectors;
 
 import static me.hwanse.chatserver.api.ApiResult.OK;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/chat-room")
 @RequiredArgsConstructor
@@ -23,22 +26,22 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
     @PostMapping
-    public ApiResult createChatRoom(@RequestBody @Valid CreateChatRoomRequest createRequest) {
-        ChatRoom chatRoom = chatRoomService.createChatRoom(createRequest.getTitle(), createRequest.getLimitUserCount());
+    public ApiResult createChatRoom(@RequestBody @Valid CreateChatRoomRequest createRequest, @AuthenticationPrincipal String userId) {
+        ChatRoom chatRoom = chatRoomService.createChatRoom(createRequest.getTitle(), createRequest.getLimitUserCount(), userId);
         return OK(chatRoom);
     }
 
     @GetMapping
-    public ApiResult getAllChatRooms() {
+    public ApiResult getAllChatRooms(@AuthenticationPrincipal String userId) {
         List<ChatRoomDto> chatRooms = chatRoomService.findAllChatRooms().stream()
-                .map(ChatRoomDto::new).collect(Collectors.toList());
+                .map(chatRoom -> new ChatRoomDto(chatRoom, userId)).collect(Collectors.toList());
         return OK(chatRooms);
     }
 
     @GetMapping("/{id}")
-    public ApiResult getChatRoom(@PathVariable Long id) {
+    public ApiResult getChatRoom(@PathVariable Long id, @AuthenticationPrincipal String userId) {
         return OK(
-                new ChatRoomDto(chatRoomService.findChatRoomById(id))
+                new ChatRoomDto(chatRoomService.findChatRoomById(id), userId)
         );
     }
 

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDto.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import me.hwanse.chatserver.chatroom.ChatRoom;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
@@ -28,7 +29,9 @@ public class ChatRoomDto {
 
     private boolean use;
 
-    public ChatRoomDto(ChatRoom chatRoom) {
+    private boolean meManager;
+
+    public ChatRoomDto(ChatRoom chatRoom, String userId) {
         this.id = chatRoom.getId();
         this.title = chatRoom.getTitle();
         this.limitUserCount = chatRoom.getLimitUserCount();
@@ -36,5 +39,6 @@ public class ChatRoomDto {
         this.createdAt = chatRoom.getCreatedAt();
         this.deletedAt = chatRoom.getDeletedAt();
         this.use = chatRoom.isUse();
+        this.meManager = StringUtils.equals(chatRoom.getManagerId(), userId);
     }
 }

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/service/ChatRoomService.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/service/ChatRoomService.java
@@ -15,8 +15,8 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
 
-    public ChatRoom createChatRoom(String title, int limitUserCount) {
-        return chatRoomRepository.save(new ChatRoom(title, limitUserCount));
+    public ChatRoom createChatRoom(String title, int limitUserCount, String managerId) {
+        return chatRoomRepository.save(new ChatRoom(title, limitUserCount, managerId));
     }
 
     public ChatRoom findChatRoomById(Long id) {

--- a/server/src/test/java/me/hwanse/chatserver/chat/ChatStompTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/chat/ChatStompTest.java
@@ -64,7 +64,7 @@ public class ChatStompTest {
     public void setup() {
         WEBSOCKET_FULL_URL = String.format("%s:%d/ws/chat", LOCAL_URL_PREFIX, port);
         completableFuture = new CompletableFuture<>();
-        chatRoomService.createChatRoom("채팅방", 5);
+        chatRoomService.createChatRoom("채팅방", 5, USER_ID);
         userService.userSignUp(USER_ID, USER_ID);
         for (int i = 0; i < 5; i++) {
             userService.userSignUp("user" + (i + 1), "user" + (i + 1));

--- a/server/src/test/java/me/hwanse/chatserver/chatroom/controller/ChatRoomControllerTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/chatroom/controller/ChatRoomControllerTest.java
@@ -46,14 +46,15 @@ class ChatRoomControllerTest {
     private ObjectMapper objectMapper;
 
     private final String TITLE = "title";
+    private final String USER_ID = "admin";
 
     @Test
     @DisplayName("채팅방 생성 API")
     @WithMockJwtAuthentication
     public void createApiTest() throws Exception {
         // given
-        ChatRoom chatRoom = getChatRoom(1L, TITLE);
-        given(chatRoomService.createChatRoom(chatRoom.getTitle(), chatRoom.getLimitUserCount())).willReturn(chatRoom);
+        ChatRoom chatRoom = getChatRoom(1L, TITLE, USER_ID);
+        given(chatRoomService.createChatRoom(chatRoom.getTitle(), chatRoom.getLimitUserCount(), chatRoom.getManagerId())).willReturn(chatRoom);
 
         CreateChatRoomRequest createRequest = new CreateChatRoomRequest();
         createRequest.setTitle(TITLE);
@@ -71,6 +72,7 @@ class ChatRoomControllerTest {
                 .andExpect(jsonPath("$.data.title").exists())
                 .andExpect(jsonPath("$.data.limitUserCount").isNumber())
                 .andExpect(jsonPath("$.data.userCount").isNumber())
+                .andExpect(jsonPath("$.data.managerId").exists())
                 .andExpect(jsonPath("$.data.createdAt").exists())
                 .andExpect(jsonPath("$.data.deletedAt").isEmpty())
                 .andExpect(jsonPath("$.data.use").value(true))
@@ -85,7 +87,7 @@ class ChatRoomControllerTest {
         List<ChatRoom> chatRooms = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             long id = i + 1;
-            chatRooms.add(getChatRoom(id, TITLE + id));
+            chatRooms.add(getChatRoom(id, TITLE + id, USER_ID));
         }
 
         given(chatRoomService.findAllChatRooms()).willReturn(chatRooms);
@@ -105,6 +107,7 @@ class ChatRoomControllerTest {
                 .andExpect(jsonPath("$.data[0].createdAt").exists())
                 .andExpect(jsonPath("$.data[0].deletedAt").isEmpty())
                 .andExpect(jsonPath("$.data[0].use").exists())
+                .andExpect(jsonPath("$.data[0].meManager").exists())
                 .andExpect(jsonPath("$.error").isEmpty());
     }
 
@@ -113,7 +116,7 @@ class ChatRoomControllerTest {
     @WithMockJwtAuthentication
     public void getChatRoomApi() throws Exception {
         // given
-        ChatRoom chatRoom = getChatRoom(1L, TITLE);
+        ChatRoom chatRoom = getChatRoom(1L, TITLE, USER_ID);
 
         given(chatRoomService.findChatRoomById(any())).willReturn(chatRoom);
 
@@ -130,16 +133,18 @@ class ChatRoomControllerTest {
                 .andExpect(jsonPath("$.data.createdAt").exists())
                 .andExpect(jsonPath("$.data.deletedAt").isEmpty())
                 .andExpect(jsonPath("$.data.use").value(true))
+                .andExpect(jsonPath("$.data.meManager").exists())
                 .andExpect(jsonPath("$.error").isEmpty());
     }
 
-    private ChatRoom getChatRoom(Long id, String title) {
+    private ChatRoom getChatRoom(Long id, String title, String managerId) {
         return ChatRoom.builder()
                 .id(id)
                 .title(title)
                 .createdAt(LocalDateTime.now())
                 .use(true)
                 .limitUserCount(5)
+                .managerId(managerId)
                 .build();
     }
 

--- a/server/src/test/java/me/hwanse/chatserver/chatroom/service/ChatRoomServiceTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/chatroom/service/ChatRoomServiceTest.java
@@ -26,22 +26,24 @@ class ChatRoomServiceTest {
     private ChatRoomRepository chatRoomRepository;
 
     private final String TITLE = "title";
+    private final String USER_ID = "admin";
 
     @Test
     @DisplayName("채팅방을 생성한다")
     public void createChatRoomTest() throws Exception {
         // given
         int limitUserCount = 5;
-        ChatRoom chatRoom = new ChatRoom(TITLE, limitUserCount);
+        ChatRoom chatRoom = new ChatRoom(TITLE, limitUserCount, USER_ID);
         given(chatRoomRepository.save(any())).willReturn(savedChatRoom(chatRoom));
 
         // when
-        ChatRoom saved = chatRoomService.createChatRoom(TITLE, limitUserCount);
+        ChatRoom saved = chatRoomService.createChatRoom(TITLE, limitUserCount, USER_ID);
 
         // then
         assertThat(saved).isNotNull();
         assertThat(saved.getId()).isNotNull();
         assertThat(saved.getTitle()).isEqualTo(chatRoom.getTitle());
+        assertThat(saved.getManagerId()).isEqualTo(USER_ID);
     }
 
     @Test
@@ -51,7 +53,7 @@ class ChatRoomServiceTest {
         List<ChatRoom> chatRooms = new ArrayList<>();
         int count = 10;
         for (int i = 0; i < count; i++) {
-            chatRooms.add(new ChatRoom(TITLE + (i + 1)));
+            chatRooms.add(new ChatRoom(TITLE + (i + 1), USER_ID));
         }
 
         given(chatRoomRepository.findByUseTrueOrderByCreatedAtDesc()).willReturn(chatRooms);
@@ -68,7 +70,7 @@ class ChatRoomServiceTest {
     public void findChatRoomByIdTest() throws Exception {
         // given
         long roomId = 1L;
-        Optional<ChatRoom> chatRoom = Optional.ofNullable(new ChatRoom(TITLE));
+        Optional<ChatRoom> chatRoom = Optional.ofNullable(new ChatRoom(TITLE, USER_ID));
         given(chatRoomRepository.findById(roomId)).willReturn(chatRoom);
 
         // when

--- a/server/src/test/java/me/hwanse/chatserver/tag/repository/TagPairRepositoryTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/tag/repository/TagPairRepositoryTest.java
@@ -31,7 +31,8 @@ class TagPairRepositoryTest {
     private static Tag tag;
 
     public TagPair setUpData() {
-        chatRoom = chatRoomRepository.save(new ChatRoom("채팅방"));
+        String userId = "admin";
+        chatRoom = chatRoomRepository.save(new ChatRoom("채팅방", userId));
         tag = tagRepository.save(new Tag("태그"));
         return tagPairRepository.save(new TagPair(chatRoom, tag));
     }


### PR DESCRIPTION
- 채팅방 생성 시 현재 인증된 사용자의 userId 값을 함께 저장
- chatRoom 조회 API 에서 현재 인증된 사용자와 실제 채팅방의 manager의 id를 비교하여 자신이 manager 인지 여부 결과값을 반환하도록 API 수정
- 변동 사항 테스트 코드 반영 및 수정