### PR TITLE
feat: 채팅방 종료 비활성화 처리 API 추가, 프론트 채팅방 종료 처리 추가

### DIFF
--- a/front/src/api/chat/chatAPI.js
+++ b/front/src/api/chat/chatAPI.js
@@ -25,5 +25,13 @@ export default {
         } catch(error) {
             console.log(error)
         }
+    },
+    async disableChatRoom(roomId) {
+        try {
+            const response = await request.patch(`/api/chat-room/${roomId}`)
+            return response.success
+        } catch (error) {
+            console.log(error)
+        }
     }
 }

--- a/front/src/views/chat/chatRoom/ChatRoomHead.vue
+++ b/front/src/views/chat/chatRoom/ChatRoomHead.vue
@@ -1,18 +1,28 @@
 <template>
     <v-toolbar dark color="primary" flat>
         <v-row class="d-flex align-center">
-            <v-btn icon @click="goToChatList">
+            <v-btn icon @click="goToChatList" title="채팅방 나가기">
                 <v-icon large>mdi-chevron-left</v-icon>
             </v-btn>
             <v-toolbar-title>{{info.title}}</v-toolbar-title>
             <v-spacer></v-spacer>
-            <v-icon class="mr-1">mdi-account-multiple</v-icon>
-            <span v-text="info.userCount" class="mr-2">{{userCount}}</span>
+            
+            <span class="mr-4">
+                <v-icon class="mr-1">mdi-account-multiple</v-icon>
+                <span v-text="info.userCount" >{{userCount}}</span>
+            </span>
+            
+            <span v-if="info.meManager" title="채팅방 종료" @click="closeChatRoom"> 
+                <v-icon class="mr-1">mdi-close-outline</v-icon>
+            </span>
+
         </v-row>
     </v-toolbar>
 </template>
 
 <script>
+import chatApi from "@/api/chat/chatAPI.js" 
+
 export default {
     props: ['info'],
     data() {
@@ -28,6 +38,13 @@ export default {
     methods: {
         goToChatList() {
             this.$router.push({name: "ChatListView"})
+        },
+        closeChatRoom() {
+            if (!alert("채팅방을 종료하시겠습니까?")) {
+                const result = chatApi.disableChatRoom(this.info.id)
+                
+                if (result) alert("채팅방이 종료되었습니다.")
+            }
         }
     }
 }

--- a/front/src/views/chat/login/SignInForm.vue
+++ b/front/src/views/chat/login/SignInForm.vue
@@ -3,7 +3,7 @@
         <v-form ref="loginForm">
             <v-text-field v-model="id" label="ID" required></v-text-field>
         
-            <v-text-field v-model="password" label="Password" required></v-text-field>
+            <v-text-field v-model="password" label="Password" type="password" required></v-text-field>
         </v-form>
         <v-btn color="success" class="mr-4" @click="signIn">
             Sign-In

--- a/front/src/views/chat/login/SignUpFormDialog.vue
+++ b/front/src/views/chat/login/SignUpFormDialog.vue
@@ -3,7 +3,7 @@
         <v-dialog v-model="signUpForm" persistent max-width="500">
             <v-card class="pa-3">
                 <v-text-field v-model="id" label="ID" required></v-text-field>
-                <v-text-field v-model="password" label="Password" required></v-text-field>
+                <v-text-field v-model="password" type="password" label="Password" required></v-text-field>
 
                 <v-btn x-large color="cancel" class="mr-3" @click="cancel">Cancel</v-btn>
                 <v-btn x-large color="primary" @click="signUp">Submit</v-btn>

--- a/server/src/main/java/me/hwanse/chatserver/api/ApiResult.java
+++ b/server/src/main/java/me/hwanse/chatserver/api/ApiResult.java
@@ -16,6 +16,9 @@ public class ApiResult<T> {
 
     private ApiError error;
 
+    public static <T> ApiResult<T> OK() {
+        return new ApiResult<>(true, null, null);
+    }
     public static <T> ApiResult<T> OK(T data) {
         return new ApiResult<>(true, data, null);
     }

--- a/server/src/main/java/me/hwanse/chatserver/auth/JwtProvider.java
+++ b/server/src/main/java/me/hwanse/chatserver/auth/JwtProvider.java
@@ -85,7 +85,9 @@ public class JwtProvider {
 
         if (StringUtils.hasText(userId)) {
             UserDetails userDetails = userDetailsProvider.loadUserByUsername(userId);
-            return Optional.of(new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities()));
+            return Optional.of(
+                new UsernamePasswordAuthenticationToken(userDetails.getUsername(), userDetails.getPassword(), userDetails.getAuthorities())
+            );
         } else {
             return Optional.empty();
         }

--- a/server/src/main/java/me/hwanse/chatserver/chat/ChatConnectInterceptor.java
+++ b/server/src/main/java/me/hwanse/chatserver/chat/ChatConnectInterceptor.java
@@ -27,9 +27,6 @@ public class ChatConnectInterceptor implements ChannelInterceptor {
         StompCommand command = stompHeaderAccessor.getCommand();
 
         if (command == StompCommand.CONNECT) {
-            System.out.println("getLogin : " + stompHeaderAccessor.getLogin());
-            System.out.println("get Authorization Header : " + stompHeaderAccessor.getFirstNativeHeader(JwtProvider.AUTHORIZATION_HEADER));
-            System.out.println("get Header : " + stompHeaderAccessor.getNativeHeader(JwtProvider.AUTHORIZATION_HEADER));
         }
 
         return ChannelInterceptor.super.preSend(message, channel);

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/controller/ChatRoomController.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/controller/ChatRoomController.java
@@ -45,4 +45,10 @@ public class ChatRoomController {
         );
     }
 
+    @PatchMapping("/{id}")
+    public ApiResult disableChatRoom(@PathVariable Long id, @AuthenticationPrincipal String userId) {
+        chatRoomService.disableChatRoom(id, userId);
+        return OK();
+    }
+
 }

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDto.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDto.java
@@ -4,12 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import me.hwanse.chatserver.chatroom.ChatRoom;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Getter
 @Setter
 @NoArgsConstructor

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/service/ChatRoomService.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/service/ChatRoomService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import me.hwanse.chatserver.chatroom.ChatRoom;
 import me.hwanse.chatserver.chatroom.repository.ChatRoomRepository;
 import me.hwanse.chatserver.exception.NotFoundException;
+import me.hwanse.chatserver.exception.NotHaveManagerPrivilege;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +31,13 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public void disableChatRoom(Long roomId) {
-        chatRoomRepository.findById(roomId).ifPresent(ChatRoom::disable);
+    public void disableChatRoom(Long roomId, String userId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new NotFoundException(ChatRoom.class, roomId));
+        if (StringUtils.equals(userId, chatRoom.getManagerId())) {
+            chatRoom.disable();
+        } else {
+            throw new NotHaveManagerPrivilege(userId);
+        }
     }
 
 }

--- a/server/src/main/java/me/hwanse/chatserver/exception/NotHaveManagerPrivilege.java
+++ b/server/src/main/java/me/hwanse/chatserver/exception/NotHaveManagerPrivilege.java
@@ -1,0 +1,9 @@
+package me.hwanse.chatserver.exception;
+
+public class NotHaveManagerPrivilege extends RuntimeException {
+
+    public NotHaveManagerPrivilege(String userId) {
+        super(String.format("'%s' not have chatroom manager privilege.", userId));
+    }
+
+}

--- a/server/src/main/resources/db/data-chatRoom.sql
+++ b/server/src/main/resources/db/data-chatRoom.sql
@@ -1,13 +1,13 @@
-INSERT INTO CHAT_ROOM(title, limit_user_count, user_count, created_at, use)
+INSERT INTO CHAT_ROOM(title, manager_id, limit_user_count, user_count, created_at, use)
 VALUES
-    ('채팅방1', 0, 0, now(), true),
-    ('채팅방2', 0, 0, now(), true),
-    ('채팅방3', 0, 0, now(), true),
-    ('채팅방4', 0, 0, now(), true),
-    ('채팅방5', 0, 0, now(), true),
-    ('채팅방6', 0, 0, now(), true),
-    ('채팅방7', 0, 0, now(), true),
-    ('채팅방8', 0, 0, now(), true),
-    ('채팅방9', 0, 0, now(), true),
-    ('채팅방10', 0, 0, now(), true);
+    ('채팅방1', 'admin', 5, 0, now(), true),
+    ('채팅방2', 'admin', 5, 0, now(), true),
+    ('채팅방3', 'admin', 5, 0, now(), true),
+    ('채팅방4', 'admin', 5, 0, now(), true),
+    ('채팅방5', 'admin', 5, 0, now(), true),
+    ('채팅방6', 'admin', 5, 0, now(), true),
+    ('채팅방7', 'admin', 5, 0, now(), true),
+    ('채팅방8', 'admin', 5, 0, now(), true),
+    ('채팅방9', 'admin', 5, 0, now(), true),
+    ('채팅방10', 'admin', 5, 0, now(), true);
 

--- a/server/src/test/java/me/hwanse/chatserver/chatroom/service/ChatRoomServiceTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/chatroom/service/ChatRoomServiceTest.java
@@ -81,6 +81,23 @@ class ChatRoomServiceTest {
         assertThat(findRoom).isEqualTo(chatRoom.get());
     }
 
+    @Test
+    @DisplayName("특정 채팅방을 닫는다")
+    public void disableChatRoomTest() throws Exception {
+        // given
+        long roomId = 1L;
+        Optional<ChatRoom> chatRoom = Optional.ofNullable(new ChatRoom(TITLE, USER_ID));
+        given(chatRoomRepository.findById(roomId)).willReturn(chatRoom);
+
+        // when
+        chatRoomService.disableChatRoom(roomId, USER_ID);
+        ChatRoom room = chatRoom.get();
+
+        // then
+        assertThat(room.isUse()).isFalse();
+        assertThat(room.getDeletedAt()).isNotNull();
+    }
+
     private ChatRoom savedChatRoom(ChatRoom chatRoom) {
         return chatRoom.toBuilder()
                 .id(1L).build();


### PR DESCRIPTION
- fix: 채팅방 id 조회 API의 meManager 관련 로직 오류사항 개선
  - JwtProvider의 Authentication 토큰 생성 시 넣을 principal, credential 정보 수정
- 서버단 채팅방 종료 처리 API 추가
  - 테스트 코드 추가, 커스텀 exception 추가
- 프론트에서 해당 채팅방의 관리자일 경우 채팅방 종료 처리 버튼 추가
  - 채팅방의 관리자인지 여부에 따라 종료버튼 출력 분기 처리 작업
  - 채팅방 비활성화 연동 처리 작업