### PR TITLE
feat: stomp 메세지의 헤더에 인증 토큰 추가

### DIFF
--- a/front/src/views/chat/chatRoom/parts/ChatTextMessageComponent.vue
+++ b/front/src/views/chat/chatRoom/parts/ChatTextMessageComponent.vue
@@ -34,7 +34,7 @@ export default {
             
             this.message = message
             let data = this.getMessageObject(this.message, "TALK")
-            this.chatSetupData.stompClient.send("/pub/chat/text/message", JSON.stringify(data))
+            this.chatSetupData.stompClient.send("/pub/chat/text/message", JSON.stringify(data), this.getAuthorizationHeader())
             this.message = ''
         },
         async handleMessage(response) {
@@ -70,6 +70,10 @@ export default {
             let chatContainer = document.getElementById("messageConatiner")
             chatContainer.scrollTop = chatContainer.scrollHeight
         },
+        getAuthorizationHeader() {
+            const token = window.sessionStorage.getItem("authToken")
+            return {"Authorization": `Bearer ${token}`}
+        }
     },
     components: {
         ChatMessage,

--- a/front/src/views/chat/chatRoom/parts/ChatVoiceComponent.vue
+++ b/front/src/views/chat/chatRoom/parts/ChatVoiceComponent.vue
@@ -76,7 +76,7 @@ export default {
                     toId: sessionId,
                     candidate: event.candidate
                 }
-                this.chatSetupData.stompClient.send("/pub/chat/voice/candidate", JSON.stringify(data))
+                this.chatSetupData.stompClient.send("/pub/chat/voice/candidate", JSON.stringify(data), this.getAuthorizationHeader())
             } else {
                 console.log('End of candidates.')
             }
@@ -99,7 +99,7 @@ export default {
                     roomId: this.chatSetupData.roomId,
                     sessionId: sessionId
                 }
-                this.chatSetupData.stompClient.send("/pub/chat/voice/leave", JSON.stringify(leaveMessage))
+                this.chatSetupData.stompClient.send("/pub/chat/voice/leave", JSON.stringify(leaveMessage), this.getAuthorizationHeader())
 
                 let index = this.connections.indexOf(sessionId)
                 if (index > -1) {
@@ -118,14 +118,14 @@ export default {
             await connection.setLocalDescription(offer)
 
             let sdpMessage = this.getSdpMessage(connection, toId)
-            this.chatSetupData.stompClient.send("/pub/chat/voice/offer", JSON.stringify(sdpMessage))
+            this.chatSetupData.stompClient.send("/pub/chat/voice/offer", JSON.stringify(sdpMessage), this.getAuthorizationHeader())
         },
         async createAnswerToSignallingServer(connection, toId) {
             const answer = await connection.createAnswer()    
             await connection.setLocalDescription(answer)
 
             let sdpMessage = this.getSdpMessage(connection, toId)
-            this.chatSetupData.stompClient.send("/pub/chat/voice/offer", JSON.stringify(sdpMessage))
+            this.chatSetupData.stompClient.send("/pub/chat/voice/offer", JSON.stringify(sdpMessage), this.getAuthorizationHeader())
         },
         async getMessageFromSignallingServer(response) {
             let message = JSON.parse(response.body)
@@ -167,6 +167,10 @@ export default {
         },
         closeMedia() {
             this.myVoiceStream.getTracks().forEach(track => track.stop())
+        },
+        getAuthorizationHeader() {
+            const token = window.sessionStorage.getItem("authToken")
+            return {"Authorization": `Bearer ${token}`}
         }
     }
 }

--- a/server/src/main/java/me/hwanse/chatserver/auth/JwtAuthenticationFilter.java
+++ b/server/src/main/java/me/hwanse/chatserver/auth/JwtAuthenticationFilter.java
@@ -53,8 +53,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(headerToken) && headerToken.startsWith(TOKEN_TYPE)) {
             return headerToken.split(" ")[1];
         }
-        if (StringUtils.hasText(queryStringToken)) {
-            return queryStringToken;
+        if (StringUtils.hasText(queryStringToken) && queryStringToken.startsWith(TOKEN_TYPE)) {
+            return queryStringToken.split(" ")[1];
         }
         return "";
     }


### PR DESCRIPTION
- 클라이언트에서 서버로 stomp 메세지 전송 시 헤더에 Authorization 추가
- 서버단 stomp message 인터셉터에서 토큰 검증 관련 로직 추가