### PR TITLE
feat: 채팅방 관련 API Hateoas, self-description 적용

### DIFF
--- a/front/src/api/chat/chatAPI.js
+++ b/front/src/api/chat/chatAPI.js
@@ -4,7 +4,7 @@ export default {
     async getChatList() {
         try {
             const response = await request.get('/api/chat-room')
-            return response.data.data
+            return response.data.data.content
         } catch(error) {
             console.log(error)
         }

--- a/server/src/docs/asciidoc/chatroom/chatroom-all.adoc
+++ b/server/src/docs/asciidoc/chatroom/chatroom-all.adoc
@@ -5,6 +5,7 @@
 :toclevels: 4
 :sectlinks:
 
+[[chatroom-create]]
 === 채팅방 생성
 
 Request
@@ -17,6 +18,7 @@ Response
 include::{snippets}/chatroom/create/response-fields.adoc[]
 include::{snippets}/chatroom/create/http-response.adoc[]
 
+[[chatroom-list]]
 === 채팅방 리스트 조회
 
 Request
@@ -28,6 +30,7 @@ Response
 include::{snippets}/chatroom/list/response-fields.adoc[]
 include::{snippets}/chatroom/list/http-response.adoc[]
 
+[[chatroom-info]]
 === 채팅방 정보 조회
 
 Request
@@ -40,6 +43,7 @@ Response
 include::{snippets}/chatroom/info/response-fields.adoc[]
 include::{snippets}/chatroom/info/http-response.adoc[]
 
+[[chatroom-disable]]
 === 채팅방 비활성화
 
 Request

--- a/server/src/main/java/me/hwanse/chatserver/api/ApiResult.java
+++ b/server/src/main/java/me/hwanse/chatserver/api/ApiResult.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 @Getter
 @ToString
@@ -16,11 +17,11 @@ public class ApiResult<T> {
 
     private ApiError error;
 
-    public static <T> ApiResult<T> OK() {
+    public static <T> ApiResult<T> Response() {
         return new ApiResult<>(true, null, null);
     }
 
-    public static <T> ApiResult<T> OK(T data) {
+    public static <T> ApiResult<T> Response(T data) {
         return new ApiResult<>(true, data, null);
     }
 

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/controller/ChatRoomController.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/controller/ChatRoomController.java
@@ -5,50 +5,73 @@ import lombok.extern.slf4j.Slf4j;
 import me.hwanse.chatserver.api.ApiResult;
 import me.hwanse.chatserver.chatroom.ChatRoom;
 import me.hwanse.chatserver.chatroom.dto.ChatRoomDto;
+import me.hwanse.chatserver.chatroom.dto.ChatRoomDtoToModelConverter;
 import me.hwanse.chatserver.chatroom.dto.CreateChatRoomRequest;
 import me.hwanse.chatserver.chatroom.service.ChatRoomService;
+import org.springframework.hateoas.*;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
-import static me.hwanse.chatserver.api.ApiResult.OK;
+import static me.hwanse.chatserver.api.ApiResult.Response;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/chat-room")
 @RequiredArgsConstructor
+@RequestMapping(value = "/api/chat-room", produces = MediaTypes.HAL_JSON_VALUE)
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
+    private final ChatRoomDtoToModelConverter converter;
 
     @PostMapping
-    public ApiResult createChatRoom(@RequestBody @Valid CreateChatRoomRequest createRequest, @AuthenticationPrincipal String userId) {
+    public ResponseEntity createChatRoom(@RequestBody @Valid CreateChatRoomRequest createRequest, @AuthenticationPrincipal String userId) {
         ChatRoom chatRoom = chatRoomService.createChatRoom(createRequest.getTitle(), createRequest.getLimitUserCount(), userId);
-        return OK(chatRoom);
+        EntityModel<ChatRoomDto> model = converter.toModel(new ChatRoomDto(chatRoom, userId));
+        model.add(linkTo(ChatRoomController.class).withRel("query-chatrooms"));
+        model.add(linkTo(ChatRoomController.class).slash(chatRoom.getId()).withRel("disable-chatroom"));
+        model.add(Link.of("/docs/index.html#chatroom-create").withRel("profile"));
+
+        return ResponseEntity
+                .created(model.getLink(IanaLinkRelations.SELF).get().toUri())
+                .body(Response(model));
     }
 
     @GetMapping
-    public ApiResult getAllChatRooms(@AuthenticationPrincipal String userId) {
+    public ResponseEntity getAllChatRooms(@AuthenticationPrincipal String userId) {
         List<ChatRoomDto> chatRooms = chatRoomService.findAllChatRooms().stream()
                 .map(chatRoom -> new ChatRoomDto(chatRoom, userId)).collect(Collectors.toList());
-        return OK(chatRooms);
+        return ResponseEntity
+                .ok(
+                        Response(converter.toCollectionModel(chatRooms))
+                );
     }
 
     @GetMapping("/{id}")
-    public ApiResult getChatRoom(@PathVariable Long id, @AuthenticationPrincipal String userId) {
-        return OK(
-                new ChatRoomDto(chatRoomService.findChatRoomById(id), userId)
-        );
+    public ResponseEntity getChatRoom(@PathVariable Long id, @AuthenticationPrincipal String userId) {
+        ChatRoomDto roomDto = new ChatRoomDto(chatRoomService.findChatRoomById(id), userId);
+        EntityModel<ChatRoomDto> model = converter.toModel(roomDto);
+        model.add(Link.of("/docs/index.html#chatroom-info").withRel("profile"));
+        if (roomDto.isMeManager()) {
+            model.add(linkTo(ChatRoomController.class).slash(roomDto.getId()).withRel("disable-chatroom"));
+        }
+
+        return ResponseEntity
+                .ok(Response(model));
     }
 
     @PatchMapping("/{id}")
     public ApiResult disableChatRoom(@PathVariable Long id, @AuthenticationPrincipal String userId) {
         chatRoomService.disableChatRoom(id, userId);
-        return OK();
+        HashMap<String, Link> responseDataMap = new HashMap<>();
+        responseDataMap.put("links", Link.of("/docs/index.html#chatroom-disable").withRel("profile"));
+        return Response(responseDataMap);
     }
 
 }

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDtoToModelConverter.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDtoToModelConverter.java
@@ -1,0 +1,28 @@
+package me.hwanse.chatserver.chatroom.dto;
+
+import me.hwanse.chatserver.chatroom.controller.ChatRoomController;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+@Component
+public class ChatRoomDtoToModelConverter implements RepresentationModelAssembler<ChatRoomDto, EntityModel<ChatRoomDto>> {
+
+    @Override
+    public EntityModel<ChatRoomDto> toModel(ChatRoomDto entity) {
+        return EntityModel.of(entity, linkTo(ChatRoomController.class).slash(entity.getId()).withSelfRel());
+    }
+
+    @Override
+    public CollectionModel<EntityModel<ChatRoomDto>> toCollectionModel(Iterable<? extends ChatRoomDto> entities) {
+        return RepresentationModelAssembler.super.toCollectionModel(entities)
+                .add(Link.of("/docs/index.html#chatroom-list").withRel("profile"));
+    }
+}

--- a/server/src/main/java/me/hwanse/chatserver/user/controller/AuthenticateController.java
+++ b/server/src/main/java/me/hwanse/chatserver/user/controller/AuthenticateController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
-import static me.hwanse.chatserver.api.ApiResult.OK;
+import static me.hwanse.chatserver.api.ApiResult.Response;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +22,7 @@ public class AuthenticateController {
     @PostMapping("/api/signin")
     public ApiResult authenticate(@RequestBody @Valid SignInRequest signInRequest) {
         String jwt = authenticateService.signIn(signInRequest.getUserId(), signInRequest.getPassword());
-        return OK(
+        return Response(
             new AuthTokenResponse(jwt)
         );
     }

--- a/server/src/main/java/me/hwanse/chatserver/user/controller/UserController.java
+++ b/server/src/main/java/me/hwanse/chatserver/user/controller/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
-import static me.hwanse.chatserver.api.ApiResult.OK;
+import static me.hwanse.chatserver.api.ApiResult.Response;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +25,7 @@ public class UserController {
     @PostMapping("/signup")
     public ApiResult signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
         User joinUser = userService.userSignUp(signUpRequest.getUserId(), signUpRequest.getPassword());
-        return OK(
+        return Response(
             new UserDto(joinUser)
         );
     }

--- a/server/src/test/java/me/hwanse/chatserver/config/RestDocsConfig.java
+++ b/server/src/test/java/me/hwanse/chatserver/config/RestDocsConfig.java
@@ -1,5 +1,6 @@
 package me.hwanse.chatserver.config;
 
+import me.hwanse.chatserver.chatroom.dto.ChatRoomDtoToModelConverter;
 import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,11 @@ public class RestDocsConfig {
         return configurer -> configurer.operationPreprocessors()
                                     .withRequestDefaults(prettyPrint())
                                     .withResponseDefaults(prettyPrint());
+    }
+
+    @Bean
+    public ChatRoomDtoToModelConverter chatRoomDtoToModelConverter() {
+        return new ChatRoomDtoToModelConverter();
     }
 
 }

--- a/server/src/test/java/me/hwanse/chatserver/document/chatroom/ChatRoomDocumentation.java
+++ b/server/src/test/java/me/hwanse/chatserver/document/chatroom/ChatRoomDocumentation.java
@@ -1,11 +1,11 @@
 package me.hwanse.chatserver.document.chatroom;
 
 import me.hwanse.chatserver.config.ApiDocumentUtil;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.request.PathParametersSnippet;
 
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -19,7 +19,8 @@ public class ChatRoomDocumentation {
     public static RestDocumentationResultHandler createChatRoomApiDocument() {
         return document("chatroom/create", ApiDocumentUtil.getDocumentRequest(),
                     requestHeaders(
-                        headerWithName(HttpHeaders.CONTENT_TYPE).description(MediaType.APPLICATION_JSON)
+                        headerWithName(HttpHeaders.CONTENT_TYPE).description(MediaType.APPLICATION_JSON),
+                        headerWithName(HttpHeaders.ACCEPT).description(MediaTypes.HAL_JSON_VALUE)
                     ),
                     requestFields(
                         fieldWithPath("title").description("생성할 채팅방 제목"),
@@ -32,10 +33,13 @@ public class ChatRoomDocumentation {
                         fieldWithPath("data.title").description("채팅방의 제목"),
                         fieldWithPath("data.limitUserCount").description("채팅방의 입장제한 인원수"),
                         fieldWithPath("data.userCount").description("채팅방의 현재 입장한 인원수"),
-                        fieldWithPath("data.managerId").description("채팅방 관리자인 유저ID"),
                         fieldWithPath("data.createdAt").description("채팅방 생성 날짜"),
                         fieldWithPath("data.deletedAt").optional().type(JsonFieldType.STRING).description("채팅방 비활성화(삭제) 날짜"),
                         fieldWithPath("data.use").description("채팅방 사용 여부"),
+                        fieldWithPath("data.managerId").description("채팅방 관리자인 유저ID"),
+                        fieldWithPath("data.meManager").description("채팅방 관리자 여부"),
+                        fieldWithPath("data.links").optional().type(JsonFieldType.ARRAY).description("생성된 채팅방과 연관된 행위 또는 profile 링크의 모음"),
+                        fieldWithPath("data.links[].*").ignored(),
                         fieldWithPath("error").optional().type(JsonFieldType.OBJECT).description("api 에러 내용(에러가 없을경우 null)")
                     )
                 );
@@ -46,15 +50,20 @@ public class ChatRoomDocumentation {
                     responseFields(
                             fieldWithPath("success").description("api 요청결과 성공 여부"),
                             fieldWithPath("data").description("api 응답 데이터 본문"),
-                            fieldWithPath("data[].id").description("채팅방 데이터의 key값"),
-                            fieldWithPath("data[].title").description("채팅방의 제목"),
-                            fieldWithPath("data[].limitUserCount").description("채팅방의 입장제한 인원수"),
-                            fieldWithPath("data[].userCount").description("채팅방의 현재 입장한 인원수"),
-                            fieldWithPath("data[].createdAt").description("채팅방 생성 날짜"),
-                            fieldWithPath("data[].deletedAt").optional().type(JsonFieldType.STRING).description("채팅방 비활성화(삭제) 날짜"),
-                            fieldWithPath("data[].use").description("채팅방 사용 여부"),
-                            fieldWithPath("data[].managerId").description("채팅방 관리자인 유저ID"),
-                            fieldWithPath("data[].meManager").description("현재 사용자가 해당 채팅방에 대한 Manager 여부"),
+                            fieldWithPath("data.links").description("채팅방 리스트 조회 api profile 링크"),
+                            fieldWithPath("data.links[].*").ignored(),
+                            fieldWithPath("data.content").description("조회된 채팅방 리스트"),
+                            fieldWithPath("data.content[].id").description("채팅방 데이터의 key값"),
+                            fieldWithPath("data.content[].title").description("채팅방의 제목"),
+                            fieldWithPath("data.content[].limitUserCount").description("채팅방의 입장제한 인원수"),
+                            fieldWithPath("data.content[].userCount").description("채팅방의 현재 입장한 인원수"),
+                            fieldWithPath("data.content[].createdAt").description("채팅방 생성 날짜"),
+                            fieldWithPath("data.content[].deletedAt").optional().type(JsonFieldType.STRING).description("채팅방 비활성화(삭제) 날짜"),
+                            fieldWithPath("data.content[].use").description("채팅방 사용 여부"),
+                            fieldWithPath("data.content[].managerId").description("채팅방 관리자인 유저ID"),
+                            fieldWithPath("data.content[].meManager").description("현재 사용자가 해당 채팅방에 대한 Manager 여부"),
+                            fieldWithPath("data.content[].links").description("채팅방 항목의 정보를 조회하는 link"),
+                            fieldWithPath("data.content[].links[].*").ignored(),
                             fieldWithPath("error").optional().type(JsonFieldType.OBJECT).description("api 에러 내용(에러가 없을경우 null)")
                     )
                 );
@@ -77,6 +86,8 @@ public class ChatRoomDocumentation {
                             fieldWithPath("data.use").description("채팅방 사용 여부"),
                             fieldWithPath("data.managerId").description("채팅방 관리자인 유저ID"),
                             fieldWithPath("data.meManager").description("현재 사용자가 해당 채팅방에 대한 Manager 여부"),
+                            fieldWithPath("data.links").optional().type(JsonFieldType.ARRAY).description("채팅방과 연관된 행위 또는 profile 링크의 모음"),
+                            fieldWithPath("data.links[].*").ignored(),
                             fieldWithPath("error").optional().type(JsonFieldType.OBJECT).description("api 에러 내용(에러가 없을경우 null)")
                     )
                 );
@@ -90,6 +101,8 @@ public class ChatRoomDocumentation {
                     responseFields(
                             fieldWithPath("success").description("api 요청결과 성공 여부"),
                             fieldWithPath("data").optional().type(JsonFieldType.OBJECT).description("api 응답 데이터 본문"),
+                            fieldWithPath("data.links").description("채팅방 비활성화 api profile 링크"),
+                            fieldWithPath("data.links.*").ignored(),
                             fieldWithPath("error").optional().type(JsonFieldType.OBJECT).description("api 에러 내용(에러가 없을경우 null)")
                     )
                 );


### PR DESCRIPTION
- 각 api 별로 Hateoas 링크, self-description profile 링크 적용
- ChatRoomDto 전용 반복되는 EntityModel 반환 로직을 재사용하기 위한 converter 등록
- 위 내용에 대한 Test 코드 및 Rest Docs 반영