### PR TITLE
fix: fix: dev 환경 mysql db 사용 시 컬럼명으로 예악어 키워드를 사용하여 발생한 이슈 수정

### DIFF
--- a/server/src/main/java/me/hwanse/chatserver/chatroom/ChatRoom.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/ChatRoom.java
@@ -1,13 +1,9 @@
 package me.hwanse.chatserver.chatroom;
 
 import lombok.*;
-import me.hwanse.chatserver.user.User;
-import org.springframework.web.socket.WebSocketSession;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -33,7 +29,8 @@ public class ChatRoom {
 
     private LocalDateTime deletedAt;
 
-    private boolean use;
+    @Column(name = "use_flag")
+    private boolean usable;
 
     public ChatRoom(String title, String managerId) {
         this(title, 5, managerId);
@@ -56,7 +53,7 @@ public class ChatRoom {
 
     public void disable() {
         this.deletedAt = LocalDateTime.now();
-        this.use = false;
+        this.usable = false;
     }
 
 }

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDto.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/dto/ChatRoomDto.java
@@ -1,13 +1,11 @@
 package me.hwanse.chatserver.chatroom.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import me.hwanse.chatserver.chatroom.ChatRoom;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -42,7 +40,7 @@ public class ChatRoomDto {
         this.userCount = chatRoom.getUserCount();
         this.createdAt = chatRoom.getCreatedAt();
         this.deletedAt = chatRoom.getDeletedAt();
-        this.use = chatRoom.isUse();
+        this.use = chatRoom.isUsable();
         this.managerId = chatRoom.getManagerId();
         this.meManager = StringUtils.equals(chatRoom.getManagerId(), userId);
     }

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/repository/ChatRoomRepository.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/repository/ChatRoomRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 @Transactional(readOnly = true)
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    List<ChatRoom> findByUseTrueOrderByCreatedAtDesc();
+    List<ChatRoom> findByUsableTrueOrderByCreatedAtDesc();
 
 }

--- a/server/src/main/java/me/hwanse/chatserver/chatroom/service/ChatRoomService.java
+++ b/server/src/main/java/me/hwanse/chatserver/chatroom/service/ChatRoomService.java
@@ -27,7 +27,7 @@ public class ChatRoomService {
     }
 
     public List<ChatRoom> findAllChatRooms() {
-        return chatRoomRepository.findByUseTrueOrderByCreatedAtDesc();
+        return chatRoomRepository.findByUsableTrueOrderByCreatedAtDesc();
     }
 
     @Transactional

--- a/server/src/main/java/me/hwanse/chatserver/user/User.java
+++ b/server/src/main/java/me/hwanse/chatserver/user/User.java
@@ -29,13 +29,14 @@ public class User {
 
     private LocalDateTime updatedAt;
 
-    private boolean use;
+    @Column(name = "use_flag")
+    private boolean usable;
 
     public User(String userId, String password) {
         this.userId = userId;
         this.password = password;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
-        this.use = true;
+        this.usable = true;
     }
 }

--- a/server/src/main/java/me/hwanse/chatserver/user/dto/UserDto.java
+++ b/server/src/main/java/me/hwanse/chatserver/user/dto/UserDto.java
@@ -27,6 +27,6 @@ public class UserDto {
         this.userId = user.getUserId();
         this.createdAt = user.getCreatedAt();
         this.updatedAt = user.getUpdatedAt();
-        this.use = user.isUse();
+        this.use = user.isUsable();
     }
 }

--- a/server/src/test/java/me/hwanse/chatserver/chatroom/controller/ChatRoomControllerTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/chatroom/controller/ChatRoomControllerTest.java
@@ -8,40 +8,26 @@ import me.hwanse.chatserver.config.RestDocsConfig;
 import me.hwanse.chatserver.config.WebTestWithSecurityConfig;
 import me.hwanse.chatserver.config.WithMockJwtAuthentication;
 import me.hwanse.chatserver.document.chatroom.ChatRoomDocumentation;
-import me.hwanse.chatserver.exception.NotHaveManagerPrivilege;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -206,7 +192,7 @@ class ChatRoomControllerTest {
                 .id(id)
                 .title(title)
                 .createdAt(LocalDateTime.now())
-                .use(true)
+                .usable(true)
                 .limitUserCount(5)
                 .managerId(managerId)
                 .build();

--- a/server/src/test/java/me/hwanse/chatserver/chatroom/service/ChatRoomServiceTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/chatroom/service/ChatRoomServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -56,7 +55,7 @@ class ChatRoomServiceTest {
             chatRooms.add(new ChatRoom(TITLE + (i + 1), USER_ID));
         }
 
-        given(chatRoomRepository.findByUseTrueOrderByCreatedAtDesc()).willReturn(chatRooms);
+        given(chatRoomRepository.findByUsableTrueOrderByCreatedAtDesc()).willReturn(chatRooms);
 
         // when
         List<ChatRoom> findChatRooms = chatRoomService.findAllChatRooms();
@@ -94,7 +93,7 @@ class ChatRoomServiceTest {
         ChatRoom room = chatRoom.get();
 
         // then
-        assertThat(room.isUse()).isFalse();
+        assertThat(room.isUsable()).isFalse();
         assertThat(room.getDeletedAt()).isNotNull();
     }
 

--- a/server/src/test/java/me/hwanse/chatserver/user/controller/UserControllerTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/user/controller/UserControllerTest.java
@@ -1,47 +1,28 @@
 package me.hwanse.chatserver.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import me.hwanse.chatserver.auth.AuthenticationAccessDenied;
-import me.hwanse.chatserver.auth.JwtAuthenticationEntryPoint;
-import me.hwanse.chatserver.auth.JwtProvider;
 import me.hwanse.chatserver.config.RestDocsConfig;
 import me.hwanse.chatserver.config.WebTestWithSecurityConfig;
 import me.hwanse.chatserver.document.user.UserDocumentation;
 import me.hwanse.chatserver.user.User;
 import me.hwanse.chatserver.user.dto.SignUpRequest;
-import me.hwanse.chatserver.user.service.UserDetailsProvider;
 import me.hwanse.chatserver.user.service.UserService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -103,7 +84,7 @@ class UserControllerTest {
                 .userId(userId)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
-                .use(true)
+                .usable(true)
                 .build();
     }
 

--- a/server/src/test/java/me/hwanse/chatserver/user/service/UserServiceTest.java
+++ b/server/src/test/java/me/hwanse/chatserver/user/service/UserServiceTest.java
@@ -3,28 +3,19 @@ package me.hwanse.chatserver.user.service;
 import me.hwanse.chatserver.exception.DuplicateException;
 import me.hwanse.chatserver.user.User;
 import me.hwanse.chatserver.user.repository.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.function.Executable;
-import org.mockito.BDDMockito;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.will;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -62,7 +53,7 @@ class UserServiceTest {
         assertThat(saved.getUserId()).isEqualTo(userId);
         assertThat(saved.getPassword()).isNotEqualTo(password);
         assertThat(passwordEncoder.matches(password, saved.getPassword())).isTrue();
-        assertThat(saved.isUse()).isTrue();
+        assertThat(saved.isUsable()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
- ChatRoom, User 엔티티에서 use 라는 필드를 사용하여 MySQL 테이블의  컬럼명도 동일하게 사용되었는대 해당 키워드는 예악어이므로
엔티티 필드명, 실제 테이블 컬럼명 변경하고 관련된 로직 Rename, 해당 컬럼을 사용하는 Repository 쿼리 수정, 테스트 코드 수정 반영